### PR TITLE
refactor: 이슈 등록 시 발표 자료 등록 방식 수정

### DIFF
--- a/.automation/scripts/automation_common.py
+++ b/.automation/scripts/automation_common.py
@@ -273,6 +273,19 @@ def render_discussion_body(topic: dict) -> str:
     return "\n".join(lines)
 
 
+def patch_discussion_links(body: str, topic: dict) -> str:
+    body = replace_markdown_section(body, "📚 발표 자료", markdown_link_or_pending(material_link(topic), "발표 자료"))
+    return replace_markdown_section(body, "🎥 발표 영상", markdown_link_or_pending(topic.get("youtube_url", ""), "발표 영상"))
+
+
+def replace_markdown_section(body: str, heading: str, replacement: str) -> str:
+    marker = f"## {heading}"
+    pattern = re.compile(rf"(^##\s+{re.escape(heading)}\s*\n)(.*?)(?=^##\s+|\Z)", re.MULTILINE | re.DOTALL)
+    if pattern.search(body):
+        return pattern.sub(lambda match: match.group(1) + replacement.rstrip() + "\n\n", body, count=1)
+    return body.rstrip() + f"\n\n{marker}\n{replacement.rstrip()}\n"
+
+
 def graphql(query: str, variables: dict) -> dict:
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
@@ -331,6 +344,29 @@ def create_discussion(repository_id: str, category_id: str, title: str, body: st
         {"repositoryId": repository_id, "categoryId": category_id, "title": title, "body": body},
     )
     return data["createDiscussion"]["discussion"]
+
+
+def get_discussion(discussion_id: str) -> dict:
+    data = graphql(
+        """
+        query($discussionId: ID!) {
+          node(id: $discussionId) {
+            ... on Discussion {
+              id
+              number
+              url
+              title
+              body
+            }
+          }
+        }
+        """,
+        {"discussionId": discussion_id},
+    )
+    discussion = data.get("node")
+    if not discussion:
+        fail("기존 Discussion을 찾을 수 없습니다")
+    return discussion
 
 
 def update_discussion(discussion_id: str, title: str, body: str) -> dict:

--- a/.automation/scripts/automation_common.py
+++ b/.automation/scripts/automation_common.py
@@ -5,7 +5,9 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
+import unicodedata
 from pathlib import Path
 
 import yaml
@@ -138,6 +140,75 @@ def validate_url(value: str, label: str) -> str:
     return value
 
 
+def extract_pdf_url(text: str) -> str:
+    if not text:
+        return ""
+    match = re.search(r"\[([^\]]+\.pdf)\]\((https?://[^\)]+)\)", text, re.IGNORECASE)
+    return match.group(2) if match else ""
+
+
+def slugify_filename(value: str) -> str:
+    cleaned = re.sub(r'[\\/:*?"<>|]', "_", value).strip()
+    return unicodedata.normalize("NFC", cleaned) or "untitled"
+
+
+def download_pdf(url: str) -> bytes:
+    headers = {"Accept": "application/octet-stream"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            content = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode(errors="replace")
+        fail(f"PDF 다운로드 실패: HTTP {error.code}\n{detail}")
+    except urllib.error.URLError as error:
+        fail(f"PDF 다운로드 실패: {error}")
+    if not content.startswith(b"%PDF"):
+        fail("받은 파일이 PDF가 아닙니다")
+    return content
+
+
+def save_pdf_attachment(pdf_url: str, round_no: int, presenter: str, title: str) -> tuple[str, str]:
+    if not pdf_url:
+        return "", ""
+    pdf_bytes = download_pdf(pdf_url)
+    basename = slugify_filename(f"[{presenter}] {title}")
+    pdf_dir = ROOT / "docs" / f"round{round_no}"
+    thumb_dir = ROOT / "images" / f"round{round_no}"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    thumb_dir.mkdir(parents=True, exist_ok=True)
+
+    pdf_path = pdf_dir / f"{basename}.pdf"
+    thumb_path = thumb_dir / f"{basename}.png"
+    pdf_path.write_bytes(pdf_bytes)
+    return str(pdf_path.relative_to(ROOT)), str(thumb_path.relative_to(ROOT))
+
+
+def material_link(topic: dict) -> str:
+    material_path = topic.get("material_path") or topic.get("material_url") or ""
+    if not material_path:
+        return ""
+    if material_path.startswith("http"):
+        return material_path
+    return f"https://github.com/{OWNER}/{REPO}/blob/main/{encode_repo_path(material_path)}"
+
+
+def thumbnail_link(topic: dict) -> str:
+    thumbnail_path = topic.get("thumbnail_path") or ""
+    if not thumbnail_path:
+        return ""
+    if thumbnail_path.startswith("http"):
+        return thumbnail_path
+    return f"https://github.com/{OWNER}/{REPO}/raw/main/{encode_repo_path(thumbnail_path)}"
+
+
+def encode_repo_path(path: str) -> str:
+    return "/".join(urllib.parse.quote(unicodedata.normalize("NFC", part), safe="()") for part in path.split("/"))
+
+
 def discussion_number_from(value: str) -> int:
     value = validate_required(value, "Discussion URL 또는 번호")
     if value.isdigit():
@@ -178,7 +249,7 @@ def render_discussion_body(topic: dict) -> str:
         topic["category"],
         "",
         "## 📚 발표 자료",
-        markdown_link_or_pending(topic.get("material_url", ""), "발표 자료"),
+        markdown_link_or_pending(material_link(topic), "발표 자료"),
         "",
         "## 🎥 발표 영상",
         markdown_link_or_pending(topic.get("youtube_url", ""), "발표 영상"),

--- a/.automation/scripts/generate_readme.py
+++ b/.automation/scripts/generate_readme.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from automation_common import README_FILE, load_data, markdown_link_or_pending, presenter_link, topic_sort_key
+from automation_common import README_FILE, load_data, markdown_link_or_pending, material_link, presenter_link, thumbnail_link, topic_sort_key
 
 
 START = "<!-- AUTO-GENERATED:TOPICS:START -->"
@@ -28,13 +28,23 @@ def render_topics() -> str:
                 category=topic["category"],
                 presenter=presenter_link(topic["presenter"]),
                 title=escape_table_cell(topic["title"]),
-                material=markdown_link_or_pending(topic.get("material_url", ""), "발표 자료"),
+                material=render_material(topic),
                 youtube=markdown_link_or_pending(topic.get("youtube_url", ""), "발표 영상"),
                 discussion=f"[바로가기]({topic['discussion_url']})",
             )
         )
     lines.append(END)
     return "\n".join(lines)
+
+
+def render_material(topic: dict) -> str:
+    link = material_link(topic)
+    if not link:
+        return "업로드 예정"
+    thumbnail = thumbnail_link(topic)
+    if thumbnail:
+        return f'<a href="{link}"><img src="{thumbnail}" width="180"/></a>'
+    return f"[발표 자료]({link})"
 
 
 def escape_table_cell(value: str) -> str:

--- a/.automation/scripts/generate_thumbnail.py
+++ b/.automation/scripts/generate_thumbnail.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from automation_common import ROOT, fail, load_data, save_data
+
+
+def needs_rebuild(thumbnail: Path, pdf: Path) -> bool:
+    if not thumbnail.exists():
+        return True
+    return thumbnail.stat().st_mtime < pdf.stat().st_mtime
+
+
+def extract_first_page(pdf: Path, thumbnail: Path) -> None:
+    thumbnail.parent.mkdir(parents=True, exist_ok=True)
+    prefix = thumbnail.with_suffix("")
+    command = ["pdftoppm", "-png", "-r", "150", "-singlefile", "-f", "1", "-l", "1", str(pdf), str(prefix)]
+    try:
+        subprocess.run(command, check=True, capture_output=True)
+    except FileNotFoundError:
+        fail("pdftoppm을 찾을 수 없습니다. poppler-utils 설치가 필요합니다.")
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.decode(errors="replace")
+        fail(f"썸네일 추출 실패: {pdf}\n{stderr}")
+    if not thumbnail.exists():
+        fail(f"썸네일 파일이 생성되지 않았습니다: {thumbnail}")
+
+
+def main() -> int:
+    data = load_data()
+    generated = 0
+    skipped = 0
+    for topic in data.get("topics") or []:
+        material_path = topic.get("material_path")
+        thumbnail_path = topic.get("thumbnail_path")
+        if not material_path or not thumbnail_path:
+            continue
+        pdf = ROOT / material_path
+        thumbnail = ROOT / thumbnail_path
+        if not pdf.exists():
+            fail(f"PDF 파일을 찾을 수 없습니다: {material_path}")
+        if not needs_rebuild(thumbnail, pdf):
+            skipped += 1
+            continue
+        extract_first_page(pdf, thumbnail)
+        generated += 1
+    save_data(data)
+    print(f"done. generated={generated} skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.automation/scripts/process_register_issue.py
+++ b/.automation/scripts/process_register_issue.py
@@ -6,11 +6,13 @@ import sys
 
 from automation_common import (
     create_discussion,
+    extract_pdf_url,
     fail,
     load_data,
     parse_issue_body,
     render_discussion_body,
     repository_info,
+    save_pdf_attachment,
     save_data,
     set_output,
     validate_category,
@@ -20,6 +22,7 @@ from automation_common import (
     validate_round,
     validate_url,
 )
+from generate_thumbnail import main as generate_thumbnail
 from generate_readme import main as generate_readme
 
 
@@ -30,7 +33,7 @@ def main() -> int:
     presenter = validate_presenter(sections.get("발표자", ""))
     category = validate_category(sections.get("카테고리", ""))
     title = validate_required(sections.get("발표 주제", ""), "발표 주제")
-    material_url = validate_url(sections.get("발표 자료 URL", ""), "발표 자료 URL")
+    pdf_url = extract_pdf_url(sections.get("발표 자료 PDF", ""))
     youtube_url = validate_url(sections.get("유튜브 URL", ""), "유튜브 URL")
 
     data = load_data()
@@ -49,12 +52,15 @@ def main() -> int:
         "presenter": presenter,
         "category": category,
         "title": title,
-        "material_url": material_url,
         "youtube_url": youtube_url,
         "summary": sections.get("핵심 개념 요약", ""),
         "mission": sections.get("미션과의 연결", ""),
         "references": sections.get("참고 자료", ""),
     }
+    material_path, thumbnail_path = save_pdf_attachment(pdf_url, round_no, presenter, title)
+    if material_path:
+        topic["material_path"] = material_path
+        topic["thumbnail_path"] = thumbnail_path
     discussion_title = f"[{round_no}회차] {title}"
     discussion = create_discussion(repository_id, category_id, discussion_title, render_discussion_body(topic))
     topic.update(
@@ -66,6 +72,7 @@ def main() -> int:
     )
     data["topics"].append(topic)
     save_data(data)
+    generate_thumbnail()
     generate_readme()
 
     set_output("round", str(round_no))

--- a/.automation/scripts/process_update_issue.py
+++ b/.automation/scripts/process_update_issue.py
@@ -8,9 +8,10 @@ from automation_common import (
     discussion_number_from,
     extract_pdf_url,
     fail,
+    get_discussion,
     load_data,
+    patch_discussion_links,
     parse_issue_body,
-    render_discussion_body,
     save_pdf_attachment,
     save_data,
     set_output,
@@ -41,8 +42,10 @@ def main() -> int:
     if youtube_url:
         topic["youtube_url"] = youtube_url
 
+    current_discussion = get_discussion(topic["discussion_id"])
     discussion_title = f"[{topic['round']}회차] {topic['title']}"
-    discussion = update_discussion(topic["discussion_id"], discussion_title, render_discussion_body(topic))
+    discussion_body = patch_discussion_links(current_discussion["body"], topic)
+    discussion = update_discussion(topic["discussion_id"], discussion_title, discussion_body)
     topic["discussion_url"] = discussion["url"]
     save_data(data)
     generate_thumbnail()

--- a/.automation/scripts/process_update_issue.py
+++ b/.automation/scripts/process_update_issue.py
@@ -6,33 +6,38 @@ import sys
 
 from automation_common import (
     discussion_number_from,
+    extract_pdf_url,
     fail,
     load_data,
     parse_issue_body,
     render_discussion_body,
+    save_pdf_attachment,
     save_data,
     set_output,
     update_discussion,
     validate_url,
 )
+from generate_thumbnail import main as generate_thumbnail
 from generate_readme import main as generate_readme
 
 
 def main() -> int:
     sections = parse_issue_body(os.environ.get("ISSUE_BODY", ""))
     discussion_number = discussion_number_from(sections.get("Discussion URL 또는 번호", ""))
-    material_url = validate_url(sections.get("발표 자료 URL", ""), "발표 자료 URL")
+    pdf_url = extract_pdf_url(sections.get("발표 자료 PDF", ""))
     youtube_url = validate_url(sections.get("유튜브 URL", ""), "유튜브 URL")
-    if not material_url and not youtube_url:
-        fail("발표 자료 URL 또는 유튜브 URL 중 하나 이상을 입력해야 합니다")
+    if not pdf_url and not youtube_url:
+        fail("발표 자료 PDF 또는 유튜브 URL 중 하나 이상을 입력해야 합니다")
 
     data = load_data()
     topic = next((item for item in data["topics"] if int(item["discussion_number"]) == discussion_number), None)
     if topic is None:
         fail(f"Discussion #{discussion_number}에 해당하는 자동화 데이터를 찾을 수 없습니다")
 
-    if material_url:
-        topic["material_url"] = material_url
+    if pdf_url:
+        material_path, thumbnail_path = save_pdf_attachment(pdf_url, int(topic["round"]), topic["presenter"], topic["title"])
+        topic["material_path"] = material_path
+        topic["thumbnail_path"] = thumbnail_path
     if youtube_url:
         topic["youtube_url"] = youtube_url
 
@@ -40,6 +45,7 @@ def main() -> int:
     discussion = update_discussion(topic["discussion_id"], discussion_title, render_discussion_body(topic))
     topic["discussion_url"] = discussion["url"]
     save_data(data)
+    generate_thumbnail()
     generate_readme()
 
     set_output("round", str(topic["round"]))

--- a/.github/ISSUE_TEMPLATE/register-topic.yml
+++ b/.github/ISSUE_TEMPLATE/register-topic.yml
@@ -65,12 +65,12 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: material_url
+  - type: textarea
+    id: material_pdf
     attributes:
-      label: 발표 자료 URL
-      description: 선택 항목입니다. 자료가 아직 없다면 비워두세요.
-      placeholder: https://...
+      label: 발표 자료 PDF
+      description: 선택 항목입니다. PDF 파일을 드래그&드롭하면 README에 썸네일이 자동 생성됩니다.
+      placeholder: 여기에 PDF 파일을 드롭하세요.
 
   - type: input
     id: youtube_url

--- a/.github/ISSUE_TEMPLATE/update-topic-links.yml
+++ b/.github/ISSUE_TEMPLATE/update-topic-links.yml
@@ -1,11 +1,11 @@
 name: 발표 자료/영상 수정
-description: 이미 등록된 발표의 발표 자료 URL 또는 유튜브 URL을 추가하거나 갱신합니다
+description: 이미 등록된 발표의 PDF 자료 또는 유튜브 URL을 추가하거나 갱신합니다
 title: "[수정] "
 body:
   - type: markdown
     attributes:
       value: |
-        등록된 발표의 자료/영상 링크를 수정합니다. Discussion URL 또는 번호를 입력하고, 갱신할 링크만 채워주세요.
+        등록된 발표의 자료/영상 정보를 수정합니다. Discussion URL 또는 번호를 입력하고, 갱신할 PDF나 링크만 채워주세요.
 
   - type: input
     id: discussion
@@ -16,12 +16,12 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: material_url
+  - type: textarea
+    id: material_pdf
     attributes:
-      label: 발표 자료 URL
-      description: 비워두면 기존 값을 유지합니다.
-      placeholder: https://...
+      label: 발표 자료 PDF
+      description: 비워두면 기존 값을 유지합니다. PDF 파일을 드래그&드롭하면 README 썸네일이 자동 갱신됩니다.
+      placeholder: 여기에 PDF 파일을 드롭하세요.
 
   - type: input
     id: youtube_url

--- a/.github/workflows/process-register-topic.yml
+++ b/.github/workflows/process-register-topic.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y poppler-utils
+
       - name: Install Python deps
         run: pip install pyyaml
 
@@ -52,6 +57,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .automation/topics.yml README.md
+          [ -d docs ] && git add docs/
+          [ -d images ] && git add images/
           if git diff --cached --quiet; then
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/process-update-topic-links.yml
+++ b/.github/workflows/process-update-topic-links.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y poppler-utils
+
       - name: Install Python deps
         run: pip install pyyaml
 
@@ -52,6 +57,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .automation/topics.yml README.md
+          [ -d docs ] && git add docs/
+          [ -d images ] && git add images/
           if git diff --cached --quiet; then
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@
 
 - **주제 등록**: `Issues` → `New issue` → `발표 주제 등록`
   - 필수: 회차, 발표일, 발표자, 카테고리, 발표 주제
-  - 선택: 발표 자료 URL, 유튜브 URL, 핵심 개념 요약, 미션과의 연결, 참고 자료
+  - 선택: 발표 자료 PDF, 유튜브 URL, 핵심 개념 요약, 미션과의 연결, 참고 자료
   - 등록하면 GitHub Discussion과 README 발표 자료 아카이브가 자동으로 생성
+  - 발표 자료 PDF를 첨부하면 첫 페이지 썸네일이 README에 표시되고, 클릭 시 발표 자료로 이동
   - 카테고리는 GitHub Discussions에도 같은 이름으로 준비되어 있어야 함
 
 - **자료/영상 수정**: `Issues` → `New issue` → `발표 자료/영상 수정`
-  - Discussion URL 또는 번호를 입력하고, 추가할 발표 자료 URL이나 유튜브 URL만 채우면 됨
+  - Discussion URL 또는 번호를 입력하고, 추가할 발표 자료 PDF나 유튜브 URL만 채우면 됨
   - 수정하면 기존 Discussion 본문과 README 발표 자료 아카이브가 자동으로 갱신


### PR DESCRIPTION
## 변경 사항
- 발표 자료 입력을 URL에서 PDF 첨부 방식으로 변경했습니다.
- 등록/수정 이슈 폼의 `발표 자료 PDF` 영역에 PDF를 드래그&드롭하면 자동화가 PDF를 `docs/roundN/`에 저장합니다.
- PDF 첫 페이지를 `images/roundN/`에 PNG 썸네일로 추출합니다.
- README 발표 자료 칸은 썸네일 이미지를 보여주고, 썸네일 클릭 시 저장된 PDF로 이동합니다.
- Discussion 본문에는 저장된 PDF 링크가 표시됩니다.

## 검증
- `python3 -m compileall .automation/scripts`
- `python3 .automation/scripts/generate_readme.py`
- issue template / workflow YAML 파싱 확인
- 임시 복사본에서 PDF 첨부 링크 파싱, PDF 저장 경로 생성, README 썸네일 링크 렌더링 확인

## 참고
- 로컬 환경에 `pdftoppm`이 없어 실제 첫 페이지 PNG 추출은 로컬에서 실행하지 못했습니다.
- GitHub Actions에서는 `poppler-utils`를 설치한 뒤 `pdftoppm`으로 썸네일을 생성하도록 구성했습니다.
