### PR TITLE
docs: README.md 양식 수정

### DIFF
--- a/.automation/scripts/automation_common.py
+++ b/.automation/scripts/automation_common.py
@@ -31,6 +31,15 @@ PRESENTERS = {
     "피즈": "wontop02",
 }
 
+PRESENTER_LABELS = {
+    "스타크": "stark",
+    "로지": "logi",
+    "초록": "chorok",
+    "러키": "lucky",
+    "도우너": "douner",
+    "피즈": "fizz",
+}
+
 CATEGORIES = [
     "Network",
     "Database",
@@ -43,6 +52,19 @@ CATEGORIES = [
     "Security",
     "Infra",
 ]
+
+CATEGORY_EMOJIS = {
+    "Network": "🌐",
+    "Database": "💾",
+    "Operating System": "⚙️",
+    "Data Structure": "🧱",
+    "Algorithm": "🧮",
+    "Computer Architecture": "🖥️",
+    "Spring": "🌱",
+    "Java": "☕",
+    "Security": "🔐",
+    "Infra": "🏗️",
+}
 
 
 def parse_issue_body(body: str) -> dict[str, str]:
@@ -224,6 +246,15 @@ def presenter_link(name: str) -> str:
     return f"[{name}](https://github.com/{login})" if login else name
 
 
+def presenter_label(name: str) -> str:
+    return PRESENTER_LABELS.get(name, "")
+
+
+def category_label(name: str) -> str:
+    emoji = CATEGORY_EMOJIS.get(name, "")
+    return f"{emoji} {name}" if emoji else name
+
+
 def markdown_link_or_pending(url: str, label: str) -> str:
     return f"[{label}]({url})" if url else "업로드 예정"
 
@@ -246,7 +277,7 @@ def render_discussion_body(topic: dict) -> str:
         topic["presenter"],
         "",
         "## 🗂️ 카테고리",
-        topic["category"],
+        category_label(topic["category"]),
         "",
         "## 📚 발표 자료",
         markdown_link_or_pending(material_link(topic), "발표 자료"),
@@ -367,6 +398,21 @@ def get_discussion(discussion_id: str) -> dict:
     if not discussion:
         fail("기존 Discussion을 찾을 수 없습니다")
     return discussion
+
+
+def delete_discussion(discussion_id: str) -> None:
+    graphql(
+        """
+        mutation($discussionId: ID!) {
+          deleteDiscussion(input: {id: $discussionId}) {
+            discussion {
+              id
+            }
+          }
+        }
+        """,
+        {"discussionId": discussion_id},
+    )
 
 
 def update_discussion(discussion_id: str, title: str, body: str) -> dict:

--- a/.automation/scripts/generate_readme.py
+++ b/.automation/scripts/generate_readme.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from automation_common import README_FILE, load_data, markdown_link_or_pending, material_link, presenter_link, thumbnail_link, topic_sort_key
+from automation_common import README_FILE, category_label, load_data, markdown_link_or_pending, material_link, presenter_link, thumbnail_link, topic_sort_key
 
 
 START = "<!-- AUTO-GENERATED:TOPICS:START -->"
@@ -15,24 +15,13 @@ def render_topics() -> str:
     topics = sorted(load_data().get("topics") or [], key=topic_sort_key)
     lines = [
         START,
-        "| 회차 | 발표일 | 카테고리 | 발표자 | 발표 주제 | 발표 자료 | 발표 영상 | Discussion |",
-        "|---|---|---|---|---|---|---|---|",
+        "| 발표 자료(클릭 시 확인 가능) | 발표 정보 |",
+        "|---|---|",
     ]
     if not topics:
-        lines.append("| - | - | - | - | 등록된 발표가 없습니다. | - | - | - |")
+        lines.append("| 등록된 발표가 없습니다. | - |")
     for topic in topics:
-        lines.append(
-            "| {round}회차 | {date} | {category} | {presenter} | {title} | {material} | {youtube} | {discussion} |".format(
-                round=topic["round"],
-                date=topic["date"],
-                category=topic["category"],
-                presenter=presenter_link(topic["presenter"]),
-                title=escape_table_cell(topic["title"]),
-                material=render_material(topic),
-                youtube=markdown_link_or_pending(topic.get("youtube_url", ""), "발표 영상"),
-                discussion=f"[바로가기]({topic['discussion_url']})",
-            )
-        )
+        lines.append(f"| {render_material(topic)} | {render_info(topic)} |")
     lines.append(END)
     return "\n".join(lines)
 
@@ -43,8 +32,21 @@ def render_material(topic: dict) -> str:
         return "업로드 예정"
     thumbnail = thumbnail_link(topic)
     if thumbnail:
-        return f'<a href="{link}"><img src="{thumbnail}" width="180"/></a>'
+        return f'<div align="center"><a href="{link}"><img src="{thumbnail}" width="100%"/></a></div>'
     return f"[발표 자료]({link})"
+
+
+def render_info(topic: dict) -> str:
+    items = [
+        f"**회차:** {topic['round']}회차",
+        f"**발표일:** {topic['date']}",
+        f"**카테고리:** {category_label(topic['category'])}",
+        f"**발표자:** {presenter_link(topic['presenter'])}",
+        f"**발표 주제:** {escape_table_cell(topic['title'])}",
+        f"**Discussion:** [바로가기]({topic['discussion_url']})",
+        f"**발표 영상:** {markdown_link_or_pending(topic.get('youtube_url', ''), '발표 영상')}",
+    ]
+    return "<br>".join(items)
 
 
 def escape_table_cell(value: str) -> str:

--- a/.automation/scripts/process_delete_issue.py
+++ b/.automation/scripts/process_delete_issue.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from automation_common import (
+    ROOT,
+    delete_discussion,
+    discussion_number_from,
+    fail,
+    load_data,
+    parse_issue_body,
+    save_data,
+    set_output,
+)
+from generate_readme import main as generate_readme
+
+
+def delete_local_file(path_text: str) -> str:
+    if not path_text or path_text.startswith("http"):
+        return ""
+    path = ROOT / path_text
+    if path.exists():
+        path.unlink()
+    return path_text
+
+
+def main() -> int:
+    sections = parse_issue_body(os.environ.get("ISSUE_BODY", ""))
+    discussion_number = discussion_number_from(sections.get("Discussion 번호", ""))
+
+    data = load_data()
+    topics = data.get("topics") or []
+    match = next(
+        ((index, topic) for index, topic in enumerate(topics) if int(topic["discussion_number"]) == discussion_number),
+        None,
+    )
+    if match is None:
+        fail(f"Discussion #{discussion_number}에 해당하는 자동화 데이터를 찾을 수 없습니다")
+
+    index, topic = match
+    material_path = delete_local_file(topic.get("material_path", ""))
+    thumbnail_path = delete_local_file(topic.get("thumbnail_path", ""))
+    delete_discussion(topic["discussion_id"])
+    topics.pop(index)
+    save_data(data)
+    generate_readme()
+
+    set_output("round", str(topic["round"]))
+    set_output("presenter", topic["presenter"])
+    set_output("title", topic["title"])
+    set_output("discussion_number", str(discussion_number))
+    set_output("material_path", material_path)
+    set_output("thumbnail_path", thumbnail_path)
+    print(f"deleted discussion #{discussion_number}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.automation/scripts/process_register_issue.py
+++ b/.automation/scripts/process_register_issue.py
@@ -10,6 +10,7 @@ from automation_common import (
     fail,
     load_data,
     parse_issue_body,
+    presenter_label,
     render_discussion_body,
     repository_info,
     save_pdf_attachment,
@@ -77,6 +78,7 @@ def main() -> int:
 
     set_output("round", str(round_no))
     set_output("presenter", presenter)
+    set_output("presenter_label", presenter_label(presenter))
     set_output("title", title)
     set_output("discussion_url", discussion["url"])
     print(f"created discussion: {discussion['url']}")

--- a/.github/ISSUE_TEMPLATE/delete-topic.yml
+++ b/.github/ISSUE_TEMPLATE/delete-topic.yml
@@ -1,0 +1,17 @@
+name: 발표 삭제
+description: 잘못 등록된 발표의 Discussion, README 항목, PDF, 썸네일을 삭제합니다
+title: "[삭제] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        잘못 등록된 발표를 삭제함. Discussion 번호만 입력하면 연결된 Discussion, README 항목, PDF, 썸네일이 함께 제거됨.
+
+  - type: input
+    id: discussion
+    attributes:
+      label: Discussion 번호
+      description: 삭제할 발표의 Discussion 번호만 입력해주세요. 예) 12
+      placeholder: "12"
+    validations:
+      required: true

--- a/.github/workflows/process-delete-topic.yml
+++ b/.github/workflows/process-delete-topic.yml
@@ -1,4 +1,4 @@
-name: Process Topic Registration
+name: Process Topic Delete
 
 on:
   issues:
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   process:
     if: |
-      startsWith(github.event.issue.title, '[등록]') &&
+      startsWith(github.event.issue.title, '[삭제]') &&
       (github.event.issue.author_association == 'OWNER' ||
        github.event.issue.author_association == 'MEMBER' ||
        github.event.issue.author_association == 'COLLABORATOR' ||
@@ -33,20 +33,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y poppler-utils
-
       - name: Install Python deps
         run: pip install pyyaml
 
-      - name: Process registration issue
+      - name: Process delete issue
         id: process
         env:
           ISSUE_BODY: ${{ github.event.issue.body }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python .automation/scripts/process_register_issue.py
+        run: python .automation/scripts/process_delete_issue.py
 
       - name: Commit and push
         id: commit
@@ -57,13 +52,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .automation/topics.yml README.md
-          [ -d docs ] && git add docs/
-          [ -d images ] && git add images/
+          [ -d docs ] && git add -A docs/
+          [ -d images ] && git add -A images/
           if git diff --cached --quiet; then
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git commit -m "docs: ${ROUND}회차 발표 주제 등록 (${PRESENTER})"
+          git commit -m "docs: ${ROUND}회차 발표 삭제 (${PRESENTER})"
           git push
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
@@ -73,35 +68,32 @@ jobs:
         env:
           ROUND: ${{ steps.process.outputs.round }}
           PRESENTER: ${{ steps.process.outputs.presenter }}
-          PRESENTER_LABEL: ${{ steps.process.outputs.presenter_label }}
           TITLE: ${{ steps.process.outputs.title }}
-          DISCUSSION_URL: ${{ steps.process.outputs.discussion_url }}
+          DISCUSSION_NUMBER: ${{ steps.process.outputs.discussion_number }}
+          MATERIAL_PATH: ${{ steps.process.outputs.material_path }}
+          THUMBNAIL_PATH: ${{ steps.process.outputs.thumbnail_path }}
         with:
           script: |
-            const round = process.env.ROUND;
-            const presenter = process.env.PRESENTER;
-            const presenterLabel = process.env.PRESENTER_LABEL;
-            const title = process.env.TITLE;
-            const discussionUrl = process.env.DISCUSSION_URL;
-            if (presenterLabel) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: [presenterLabel]
-              });
-            }
+            const lines = [
+              "삭제 완료되었습니다.",
+              "",
+              `- Discussion: #${process.env.DISCUSSION_NUMBER}`,
+              `- 발표: ${process.env.ROUND}회차 - ${process.env.PRESENTER} / ${process.env.TITLE}`,
+              "- README 발표 자료 아카이브가 갱신되었습니다."
+            ];
+            if (process.env.MATERIAL_PATH) lines.push(`- 삭제된 PDF: \`${process.env.MATERIAL_PATH}\``);
+            if (process.env.THUMBNAIL_PATH) lines.push(`- 삭제된 썸네일: \`${process.env.THUMBNAIL_PATH}\``);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `등록 완료되었습니다.\n\n- Discussion: ${discussionUrl}\n- README 발표 목록이 갱신되었습니다.`
+              body: lines.join("\n")
             });
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              title: `[등록] ${round}회차 - ${presenter} / ${title}`,
+              title: `[삭제] ${process.env.ROUND}회차 - ${process.env.PRESENTER} / ${process.env.TITLE}`,
               state: 'closed',
               state_reason: 'completed'
             });

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@
 ## 📚 발표 자료 아카이브
 
 <!-- AUTO-GENERATED:TOPICS:START -->
-| 회차 | 발표일 | 카테고리 | 발표자 | 발표 주제 | 발표 자료 | 발표 영상 | Discussion |
-|---|---|---|---|---|---|---|---|
-| - | - | - | - | 등록된 발표가 없습니다. | - | - | - |
+| 발표 자료(클릭 시 확인 가능) | 발표 정보 |
+|---|---|
+| 등록된 발표가 없습니다. | - |
 <!-- AUTO-GENERATED:TOPICS:END -->
 
 ---
@@ -72,3 +72,7 @@
 - **자료/영상 수정**: `Issues` → `New issue` → `발표 자료/영상 수정`
   - Discussion URL 또는 번호를 입력하고, 추가할 발표 자료 PDF나 유튜브 URL만 채우면 됨
   - 수정하면 기존 Discussion 본문과 README 발표 자료 아카이브가 자동으로 갱신
+
+- **발표 삭제**: `Issues` → `New issue` → `발표 삭제`
+  - Discussion 번호만 입력하면 됨
+  - 삭제하면 연결된 Discussion, README 항목, PDF, 썸네일이 함께 제거


### PR DESCRIPTION
## 변경 사항
- 발표 아카이브 README 표를 2열 카드형 구조로 변경했습니다.
- 발표 정보 순서를 회차, 발표일, 카테고리, 발표자, 발표 주제, Discussion, 발표 영상 순서로 정리했습니다.
- 카테고리명 앞에 이모지가 자동으로 붙도록 했습니다.
- 주제 등록 성공 시 발표자에 맞는 기존 라벨을 이슈에 자동 부착합니다.
- `발표 삭제` 이슈 폼과 workflow를 추가했습니다.
  - Discussion 번호만 입력하면 Discussion, README 항목, PDF, 썸네일을 함께 제거합니다.

## 검증
- `python3 -m compileall .automation/scripts`
- issue template / workflow YAML 파싱
- `git diff --check`
- mock 기반 삭제 플로우 검증
- 샘플 데이터로 README 카드형 렌더링 검증
