### PR TITLE
fix: 발표 자료 수정 시 Discussion 권한 오류 수정

### DIFF
--- a/.automation/scripts/process_update_issue.py
+++ b/.automation/scripts/process_update_issue.py
@@ -8,14 +8,11 @@ from automation_common import (
     discussion_number_from,
     extract_pdf_url,
     fail,
-    get_discussion,
     load_data,
-    patch_discussion_links,
     parse_issue_body,
     save_pdf_attachment,
     save_data,
     set_output,
-    update_discussion,
     validate_url,
 )
 from generate_thumbnail import main as generate_thumbnail
@@ -42,11 +39,6 @@ def main() -> int:
     if youtube_url:
         topic["youtube_url"] = youtube_url
 
-    current_discussion = get_discussion(topic["discussion_id"])
-    discussion_title = f"[{topic['round']}회차] {topic['title']}"
-    discussion_body = patch_discussion_links(current_discussion["body"], topic)
-    discussion = update_discussion(topic["discussion_id"], discussion_title, discussion_body)
-    topic["discussion_url"] = discussion["url"]
     save_data(data)
     generate_thumbnail()
     generate_readme()
@@ -54,8 +46,8 @@ def main() -> int:
     set_output("round", str(topic["round"]))
     set_output("presenter", topic["presenter"])
     set_output("title", topic["title"])
-    set_output("discussion_url", discussion["url"])
-    print(f"updated discussion: {discussion['url']}")
+    set_output("discussion_url", topic["discussion_url"])
+    print(f"updated topic links: {topic['discussion_url']}")
     return 0
 
 

--- a/.github/workflows/process-update-topic-links.yml
+++ b/.github/workflows/process-update-topic-links.yml
@@ -84,7 +84,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `수정 완료되었습니다.\n\n- Discussion: ${discussionUrl}\n- README 발표 목록이 갱신되었습니다.`
+              body: `수정 완료되었습니다.\n\n- Discussion: ${discussionUrl}\n- README 발표 목록이 갱신되었습니다.\n- Discussion 본문은 필요한 경우 직접 수정해주세요.`
             });
             await github.rest.issues.update({
               owner: context.repo.owner,

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@
 
 - **자료/영상 수정**: `Issues` → `New issue` → `발표 자료/영상 수정`
   - Discussion URL 또는 번호를 입력하고, 추가할 발표 자료 PDF나 유튜브 URL만 채우면 됨
-  - 수정하면 기존 Discussion 본문과 README 발표 자료 아카이브가 자동으로 갱신
+  - 수정하면 README 발표 자료 아카이브가 자동으로 갱신
+  - Discussion 본문은 필요한 경우 직접 수정
 
 - **발표 삭제**: `Issues` → `New issue` → `발표 삭제`
   - Discussion 번호만 입력하면 됨


### PR DESCRIPTION
## Summary
- 발표 자료/영상 수정 workflow에서 기존 Discussion 본문을 `updateDiscussion`으로 갱신하지 않도록 변경했습니다.
- 수정 이슈는 `.automation/topics.yml`, PDF/썸네일, README 발표 자료 아카이브만 갱신합니다.
- README와 성공 댓글 문구에서 Discussion 본문 자동 갱신 표현을 제거했습니다.

## Root Cause
- 수정 이슈 실패 원인은 GitHub Actions `GITHUB_TOKEN`이 기존 org Discussion 본문을 `updateDiscussion` mutation으로 수정할 권한이 없어 `FORBIDDEN`이 발생한 것입니다.
- 등록 workflow의 `createDiscussion`은 가능하지만, 기존 Discussion 수정 권한은 별도로 막혀 있었습니다.

## Behavior
- 발표 자료 PDF나 유튜브 URL을 수정 이슈로 추가하면 README 아카이브는 정상 갱신됩니다.
- Discussion 본문은 필요한 경우 직접 수정합니다.

## Test
- `python3 -m compileall .automation/scripts`
- GitHub Issue Form/Workflow YAML 파싱
- `python3 .automation/scripts/generate_readme.py`
- 임시 복사본에서 샘플 수정 이슈 본문으로 README 발표 영상 링크 갱신 확인
- `git diff --check`
