### PR TITLE
docs: README 발표 자료 썸네일 크기 수정

### DIFF
--- a/.automation/scripts/generate_readme.py
+++ b/.automation/scripts/generate_readme.py
@@ -32,7 +32,7 @@ def render_material(topic: dict) -> str:
         return "업로드 예정"
     thumbnail = thumbnail_link(topic)
     if thumbnail:
-        return f'<div align="center"><a href="{link}"><img src="{thumbnail}" width="100%"/></a></div>'
+        return f'<div align="center"><a href="{link}"><img src="{thumbnail}" width="300"/></a></div>'
     return f"[발표 자료]({link})"
 
 


### PR DESCRIPTION
## Summary
- README 발표 자료 썸네일 렌더링 크기를 `width="100%"`에서 `width="300"`으로 변경했습니다.
- 테크살롱 README와 동일한 기준으로, 썸네일이 표 왼쪽 칸을 과하게 채우지 않도록 조정했습니다.

## Test
- `python3 .automation/scripts/generate_readme.py`
- `python3 -m compileall .automation/scripts/generate_readme.py`
- `git diff --check`
- 임시 데이터로 PDF/썸네일 항목 생성 후 README에 `width="300"` 출력 확인
